### PR TITLE
Vulnerability fix: bumping cdap & hadoop version 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
     <docs.dir>docs</docs.dir>
     <!-- this is here because project.basedir evaluates to null in the script build step -->
     <main.basedir>${project.basedir}</main.basedir>
-    <cdap.version>6.8.0</cdap.version>
-    <hadoop.version>2.10.2</hadoop.version>
+    <cdap.version>6.1.0-SNAPSHOT</cdap.version>
+    <hadoop.version>2.3.0</hadoop.version>
     <hydrator.version>2.3.0-SNAPSHOT</hydrator.version>
     <junit.version>4.11</junit.version>
     <mockito.version>1.10.19</mockito.version>
@@ -157,6 +157,10 @@
       <scope>provided</scope>
       <exclusions>
         <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
@@ -199,7 +203,7 @@
     <!-- tests -->
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline2_2.11</artifactId>
+      <artifactId>cdap-data-pipeline</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
     </dependency>
@@ -348,7 +352,7 @@
         <version>1.1.0</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[6.8.0,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
     <docs.dir>docs</docs.dir>
     <!-- this is here because project.basedir evaluates to null in the script build step -->
     <main.basedir>${project.basedir}</main.basedir>
-    <cdap.version>6.1.0-SNAPSHOT</cdap.version>
-    <hadoop.version>2.3.0</hadoop.version>
+    <cdap.version>6.8.0</cdap.version>
+    <hadoop.version>2.10.2</hadoop.version>
     <hydrator.version>2.3.0-SNAPSHOT</hydrator.version>
     <junit.version>4.11</junit.version>
     <mockito.version>1.10.19</mockito.version>
@@ -199,7 +199,7 @@
     <!-- tests -->
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline</artifactId>
+      <artifactId>cdap-data-pipeline2_2.11</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
     </dependency>
@@ -348,7 +348,7 @@
         <version>1.1.0</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[6.8.0,7.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>


### PR DESCRIPTION
Hadoop version 2.3.0 has transitive dependency on log4j 1.2.17 which has vulnerabilities. This PR is to resolve the vulnerabilities by bumping hadoop to version 2.10.2 and also update cdap version to the latest version.

Maven build succeeded with one test failing which required appropriate system properties.